### PR TITLE
To work around pygments 2.12 code block linenos formatting issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 pillow
 sphinx==4.4.0
 sphinx-rtd-theme==1.0.0
+# To workaround 2.12 linenos issue in sphinx:
+# https://github.com/pygments/pygments/issues/632
+pygments==2.11.2
 furo
-docutils<0.17
+docutils


### PR DESCRIPTION
In 2.12, https://github.com/pygments/pygments/issues/632 changed the element layout in the HTML formatter and it made the linenos misaligned with `html_codeblock_linenos_style = 'table'` in sphinx.  Before I find a good way to fix the issue, stick with pygments 2.11.2 to work around the issue.